### PR TITLE
Support negative Content-Length in DataFromReader (#1981)

### DIFF
--- a/render/reader.go
+++ b/render/reader.go
@@ -21,7 +21,9 @@ type Reader struct {
 // Render (Reader) writes data with custom ContentType and headers.
 func (r Reader) Render(w http.ResponseWriter) (err error) {
 	r.WriteContentType(w)
-	r.Headers["Content-Length"] = strconv.FormatInt(r.ContentLength, 10)
+	if r.ContentLength >= 0 {
+		r.Headers["Content-Length"] = strconv.FormatInt(r.ContentLength, 10)
+	}
 	r.writeHeaders(w, r.Headers)
 	_, err = io.Copy(w, r.Reader)
 	return

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -498,3 +498,26 @@ func TestRenderReader(t *testing.T) {
 	assert.Equal(t, headers["Content-Disposition"], w.Header().Get("Content-Disposition"))
 	assert.Equal(t, headers["x-request-id"], w.Header().Get("x-request-id"))
 }
+
+func TestRenderReaderNoContentLength(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	body := "#!PNG some raw data"
+	headers := make(map[string]string)
+	headers["Content-Disposition"] = `attachment; filename="filename.png"`
+	headers["x-request-id"] = "requestId"
+
+	err := (Reader{
+		ContentLength: -1,
+		ContentType:   "image/png",
+		Reader:        strings.NewReader(body),
+		Headers:       headers,
+	}).Render(w)
+
+	assert.NoError(t, err)
+	assert.Equal(t, body, w.Body.String())
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.NotContains(t, "Content-Length", w.Header())
+	assert.Equal(t, headers["Content-Disposition"], w.Header().Get("Content-Disposition"))
+	assert.Equal(t, headers["x-request-id"], w.Header().Get("x-request-id"))
+}


### PR DESCRIPTION
You can get an http.Response with ContentLength set to -1 (Chunked encoding), so
for DataFromReader to be useful for those we need to support that.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integrations systems such as TravisCI.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

